### PR TITLE
Fix beforeinput: pass in view.state instead of view

### DIFF
--- a/src/history.js
+++ b/src/history.js
@@ -412,8 +412,16 @@ export function history(config) {
     props: {
       handleDOMEvents: {
         beforeinput(view, e) {
-          if (e.inputType == "historyUndo") return undo(view.state)
-          if (e.inputType == "historyRedo") return redo(view.state)
+          if (e.inputType == "historyUndo") {
+            let undone = undo(view.state, view.dispatch)
+            if (undone) e.preventDefault()
+            return undone
+          }
+          if (e.inputType == "historyRedo") {
+            let redone = redo(view.state, view.dispatch)
+            if (redone) e.preventDefault()
+            return redone
+          }
           return false
         }
       }

--- a/src/history.js
+++ b/src/history.js
@@ -412,8 +412,8 @@ export function history(config) {
     props: {
       handleDOMEvents: {
         beforeinput(view, e) {
-          if (e.inputType == "historyUndo") return undo(view)
-          if (e.inputType == "historyRedo") return redo(view)
+          if (e.inputType == "historyUndo") return undo(view.state)
+          if (e.inputType == "historyRedo") return redo(view.state)
           return false
         }
       }


### PR DESCRIPTION
`undo` and `redo` both take in `EditorState` as arguments instead of `EditorView`. 

The code surprisingly doesn't throw an error because [`pluginKey.getState(state)` resolves to `state[this.key]`](https://github.com/ProseMirror/prosemirror-state/blob/master/src/plugin.js) (which results in `null`); however, `undo` and `redo` always returns `false`, as `!hist` (where `hist = historyKey.getState(state)`) is a true condition.