### PR TITLE
Add method `disableHistory` to disable history on the given transaction

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -15,3 +15,5 @@ comes up in other situations as well.)
 @redoDepth
 
 @closeHistory
+
+@disableHistory

--- a/src/history.js
+++ b/src/history.js
@@ -265,6 +265,8 @@ function applyTransaction(history, state, tr, options) {
   let historyTr = tr.getMeta(historyKey), rebased
   if (historyTr) return historyTr.historyState
 
+  if (tr.getMeta(disableHistoryKey)) return history
+
   if (tr.getMeta(closeHistoryKey)) history = new HistoryState(history.done, history.undone, null, 0)
 
   let appended = tr.getMeta("appendedTransaction")
@@ -369,8 +371,16 @@ export function closeHistory(tr) {
   return tr.setMeta(closeHistoryKey, true)
 }
 
+// :: (Transaction) → Transaction
+// Set a flag on the given transaction that will prevent further steps
+// append to the history stack.
+export function disableHistory(tr) {
+  return tr.setMeta(disableHistoryKey, true)
+}
+
 const historyKey = new PluginKey("history")
 const closeHistoryKey = new PluginKey("closeHistory")
+const disableHistoryKey = new PluginKey("disableHistory")
 
 // :: (?Object) → Plugin
 // Returns a plugin that enables the undo history for an editor. The

--- a/test/test-history.js
+++ b/test/test-history.js
@@ -4,7 +4,7 @@ const {EditorState, Plugin, TextSelection} = require("prosemirror-state")
 const {ReplaceStep} = require("prosemirror-transform")
 const ist = require("ist")
 
-const {history, closeHistory, undo, redo, undoDepth, redoDepth} = require("..")
+const {history, closeHistory, disableHistory, undo, redo, undoDepth, redoDepth} = require("..")
 
 let plugin = history()
 
@@ -395,5 +395,17 @@ describe("history", () => {
     rebase.mapping.setMirror(0, 2)
     state = state.apply(rebase)
     state = command(state, undo)
+  })
+
+  it("test disable history", () => {
+    let state = mkState()
+    state = type(state, "aa")
+    state = state.apply(disableHistory(state.tr).insertText('bb', 3))
+    state = type(state, "cc")
+    ist(state.doc, doc(p('aabbcc')), eq)
+    state = command(state, undo)
+    ist(state.doc, doc(p("aabb")), eq)
+    state = command(state, undo)
+    ist(state.doc, doc(p('bb')), eq)
   })
 })


### PR DESCRIPTION
Hi marijnh,

I am building a codeblock node based on CodeMirror and ProseMirror.

Similar to the official codemirror example, a code editor in prosemirror. The difference is that I am using the codemirror6 and the code editor have tabs.

When change the tab, I need to change the content of codeblock node dynamicly by dispatching `tr.replaceWith`. Then the change will be stored in history which is unwanted.

So I make this PR.

![2022-01-30 02 34 44](https://user-images.githubusercontent.com/18365078/151673249-b15533bb-3e86-4d5c-897f-bc6125893e0f.gif)

