### PR TITLE
Prevent history commands when view is not editable

### DIFF
--- a/src/history.ts
+++ b/src/history.ts
@@ -411,7 +411,7 @@ export function history(config: HistoryOptions = {}): Plugin {
         beforeinput(view, e: Event) {
           let inputType = (e as InputEvent).inputType
           let command = inputType == "historyUndo" ? undo : inputType == "historyRedo" ? redo : null
-          if (!command) return false
+          if (!command || !view.editable) return false
           e.preventDefault()
           return command(view.state, view.dispatch)
         }


### PR DESCRIPTION
## Description

This pull request fixes an issue where history commands (undo/redo) could still be triggered even when the editor view is not editable. The change ensures that the `beforeinput` event handler properly checks the `view.editable` flag before executing history commands.

### Why this is needed:
The current behavior allows undo/redo operations even when the editor is not in an editable state, which is inconsistent with expected behavior. This fix resolves that issue by ensuring that history commands are only available in editable mode.