### PR TITLE
resetHistory command to forget the undo/redo history

### DIFF
--- a/src/history.ts
+++ b/src/history.ts
@@ -290,6 +290,8 @@ function applyTransaction(history: HistoryState, state: EditorState, tr: Transac
     return new HistoryState(history.done.rebased(tr, rebased),
                             history.undone.rebased(tr, rebased),
                             mapRanges(history.prevRanges!, tr.mapping), history.prevTime, history.prevComposition)
+  } else if (rebased = tr.getMeta("resetHistory")) {
+    return new HistoryState(Branch.empty, Branch.empty, null, 0, -1)
   } else {
     return new HistoryState(history.done.addMaps(tr.mapping.maps),
                             history.undone.addMaps(tr.mapping.maps),
@@ -445,6 +447,16 @@ export const undoNoScroll = buildCommand(false, false)
 /// A command function that redoes the last undone change. Don't
 /// scroll the selection into view.
 export const redoNoScroll = buildCommand(true, false)
+
+/// A command function that resets the history without the need to
+/// restart the plugin.
+export function resetHistory(): Command {
+  return (state, dispatch) => {
+    if (dispatch)
+      dispatch(state.tr.setMeta(historyKey, "resetHistory"))
+    return true
+  }
+}
 
 /// The amount of undoable events available in a given state.
 export function undoDepth(state: EditorState) {

--- a/test/test-history.ts
+++ b/test/test-history.ts
@@ -3,7 +3,7 @@ import {Slice, Fragment, Node} from "prosemirror-model"
 import {EditorState, Plugin, TextSelection, Command} from "prosemirror-state"
 import {ReplaceStep} from "prosemirror-transform"
 import ist from "ist"
-import {history, closeHistory, undo, redo, undoDepth, redoDepth} from "prosemirror-history"
+import {history, closeHistory, undo, redo, undoDepth, redoDepth, resetHistory} from "prosemirror-history"
 
 let plugin = history()
 
@@ -44,6 +44,15 @@ describe("history", () => {
     state = command(state, undo)
     ist(state.doc, doc(p()), eq)
     state = command(state, redo)
+    ist(state.doc, doc(p("ab")), eq)
+  })
+
+  it("can reset history", () => {
+    let state = mkState()
+    state = type(state, "a")
+    state = type(state, "b")
+    state = command(state, resetHistory())
+    state = command(state, undo)
     ist(state.doc, doc(p("ab")), eq)
   })
 


### PR DESCRIPTION
This is a PR for [this discussion](https://discuss.prosemirror.net/t/reset-history-plugin-state/1883/6)

The effect of `resetHistory` is the same of running the plugin's state.init() function again.

Sometimes I want to reuse an editor with a different document, but I want to forget the history, because it would get me to the previous, different document.